### PR TITLE
Add setting to show/hide event location

### DIFF
--- a/app/src/main/java/com/flowmosaic/calendar/analytics/AgendaWidgetLogger.kt
+++ b/app/src/main/java/com/flowmosaic/calendar/analytics/AgendaWidgetLogger.kt
@@ -61,6 +61,7 @@ class AgendaWidgetLogger internal constructor(
         SHOW_END_TIME("show_end_time"),
         SHOW_ACTION_BUTTONS("show_action_buttons"),
         SHOW_NO_EVENTS_TEXT("show_no_events_text"),
+        SHOW_LOCATION("show_location"),
         USE_12_HOUR("use_12_hour"),
         DATE_SEPARATOR("date_separator"),
         ALIGN_BOTTOM("align_bottom"),

--- a/app/src/main/java/com/flowmosaic/calendar/data/CalendarDateUtils.kt
+++ b/app/src/main/java/com/flowmosaic/calendar/data/CalendarDateUtils.kt
@@ -34,9 +34,10 @@ object CalendarDateUtils {
     fun getCalendarEventText(
         calendarEvent: CalendarEvent,
         context: Context,
-        widgetId: String
+        widgetId: String,
+        locationAllowed: Boolean,
     ): String {
-        return if (calendarEvent.isAllDay) {
+        var text = if (calendarEvent.isAllDay) {
             calendarEvent.title
         } else {
             val prefs = AgendaWidgetPrefs(context)
@@ -48,6 +49,11 @@ object CalendarDateUtils {
                 )
             "$formattedTimeRange | ${calendarEvent.title}"
         }
+
+        if (locationAllowed && !calendarEvent.location.isNullOrBlank()) {
+            text += " @ ${calendarEvent.location}"
+        }
+        return text
     }
 
     fun getDateFromTimestamp(timestamp: Long): Date {

--- a/app/src/main/java/com/flowmosaic/calendar/prefs/AgendaWidgetPrefs.kt
+++ b/app/src/main/java/com/flowmosaic/calendar/prefs/AgendaWidgetPrefs.kt
@@ -24,6 +24,7 @@ class AgendaWidgetPrefs internal constructor(private val sharedPreferences: Shar
         private const val PREF_SHOW_ACTION_BUTTONS = "key_show_action_buttons"
         private const val PREF_SHOW_NO_UPCOMING_EVENTS = "key_show_no_upcoming_events"
         private const val PREF_SHOW_END_TIME = "key_show_end_time"
+        private const val PREF_SHOW_LOCATION = "key_show_location"
         private const val PREF_NUMBER_OF_DAYS = "key_number_of_days"
         private const val PREF_TEXT_COLOR = "key_text_color"
         private const val PREF_LAST_LOGGED = "lastLogged"
@@ -150,6 +151,20 @@ class AgendaWidgetPrefs internal constructor(private val sharedPreferences: Shar
     fun setShowEndTime(showEndTime: Boolean, widgetId: String) {
         val prefsKey = getKeyWithWidgetIdSave(PREF_SHOW_END_TIME, widgetId)
         sharedPreferences.edit().putBoolean(prefsKey, showEndTime).apply()
+    }
+
+    fun getShowLocation(widgetId: String): Boolean {
+        val (prefsKey, prefExists) = getKeyWithWidgetId(PREF_SHOW_LOCATION, widgetId)
+        val result = sharedPreferences.getBoolean(prefsKey, false)
+        if (!prefExists) {
+            setShowLocation(result, widgetId)
+        }
+        return result
+    }
+
+    fun setShowLocation(showLocation: Boolean, widgetId: String) {
+        val prefsKey = getKeyWithWidgetIdSave(PREF_SHOW_LOCATION, widgetId)
+        sharedPreferences.edit().putBoolean(prefsKey, showLocation).apply()
     }
 
     fun getNumberOfDays(widgetId: String): Int {

--- a/app/src/main/java/com/flowmosaic/calendar/remoteviews/EventsRemoteViewsFactory.kt
+++ b/app/src/main/java/com/flowmosaic/calendar/remoteviews/EventsRemoteViewsFactory.kt
@@ -76,7 +76,8 @@ class EventsRemoteViewsFactory(private val context: Context, intent: Intent) :
                 is CalendarViewItem.Event -> CalendarDateUtils.getCalendarEventText(
                     item.event,
                     context,
-                    widgetId
+                    widgetId,
+                    prefs.getShowLocation(widgetId)
                 )
             }
 

--- a/app/src/main/java/com/flowmosaic/calendar/ui/screens/PreferencesScreen.kt
+++ b/app/src/main/java/com/flowmosaic/calendar/ui/screens/PreferencesScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.flowmosaic.calendar.R
 import com.flowmosaic.calendar.analytics.AgendaWidgetLogger
@@ -46,7 +47,7 @@ fun PreferencesScreen(appWidgetId: Int, onCloseClick: (() -> Unit)? = null) {
             content = { GeneralPrefsSection(widgetId, logger, prefs) }
         ),
         PreferenceSection(
-            title = context.getString(R.string.prefs_title_date_time),
+            title = context.getString(R.string.prefs_title_date_time_location),
             content = { DateAndTimePrefsSection(widgetId, logger, prefs) }
         ),
         PreferenceSection(
@@ -163,6 +164,9 @@ fun DateAndTimePrefsSection(
     val use12HourFormat = remember {
         mutableStateOf(prefs.getHourFormat12(widgetId))
     }
+    val showLocation = remember {
+        mutableStateOf(prefs.getShowLocation(widgetId))
+    }
 
     CheckboxRow(
         displayText = context.getString(R.string.show_end_time),
@@ -181,6 +185,16 @@ fun DateAndTimePrefsSection(
         saveCheckboxValue = { newValue: Boolean ->
             use12HourFormat.value = newValue
             prefs.setHourFormat12(newValue, widgetId)
+        },
+        logger = logger
+    )
+    CheckboxRow(
+        displayText = stringResource(id = R.string.show_location),
+        loggingItem = AgendaWidgetLogger.PrefsScreenItemName.SHOW_LOCATION,
+        checkboxValue = showLocation,
+        saveCheckboxValue = { newValue: Boolean ->
+            showLocation.value = newValue
+            prefs.setShowLocation(newValue, widgetId)
         },
         logger = logger
     )

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -8,6 +8,7 @@
     <string name="show_action_buttons">Aktionstasten anzeigen</string>
     <string name="show_no_upcoming_events">Text \"Keine bevorstehenden Ereignisse anzeigen\" anzeigen</string>
     <string name="use_12_hour_format">Im 12-Stunden-Format anzeigen</string>
+    <string name="show_location">Ort anzeigen</string>
     <string name="date_separator_visible">Datums-Trennzeichen anzeigen</string>
     <string name="align_widget_bottom">Unterer Rand Ausrichtung</string>
     <string name="font_size">Schriftgröße</string>
@@ -31,7 +32,7 @@
     <string name="text_alignment">Textausrichtung</string>
     <string name="prefs_title_editing_default_config">Bearbeiten der Standardkonfiguration</string>
     <string name="prefs_title_general">Allgemein</string>
-    <string name="prefs_title_date_time">Datum und Uhrzeit</string>
+    <string name="prefs_title_date_time_location">Datum und Uhrzeit, Ort</string>
     <string name="prefs_title_appearance">Erscheinungsbild</string>
     <string name="no_upcoming_events">Keine anstehenden Ereignisse</string>
     <string name="active_widgets">Widget-Konfiguration</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -8,6 +8,7 @@
     <string name="show_action_buttons">Mostrar botones de acción</string>
     <string name="show_no_upcoming_events">Mostrar texto \"Sin eventos próximos\"</string>
     <string name="use_12_hour_format">Usar formato de 12 horas</string>
+    <string name="show_location">Mostrar ubicación</string>
     <string name="date_separator_visible">Mostrar separador de fecha</string>
     <string name="align_widget_bottom">Alineación inferior</string>
     <string name="font_size">Tamaño de fuente</string>
@@ -30,7 +31,7 @@
     <string name="text_alignment">Alineación de texto</string>
     <string name="prefs_title_editing_default_config">Edición de la configuración predeterminada</string>
     <string name="prefs_title_general">General</string>
-    <string name="prefs_title_date_time">Fecha y hora</string>
+    <string name="prefs_title_date_time_location">Fecha y hora, Ubicación</string>
     <string name="prefs_title_appearance">Apariencia</string>
     <string name="no_upcoming_events">No hay eventos próximos</string>
     <string name="active_widgets">Configuración del widget</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -8,6 +8,7 @@
     <string name="show_action_buttons">Afficher les boutons d\'action</string>
     <string name="show_no_upcoming_events">"Afficher le texte \"Aucun événement à venir\" "</string>
     <string name="use_12_hour_format">Utiliser le format 12 heures</string>
+    <string name="show_location">Afficher le lieu</string>
     <string name="date_separator_visible">Afficher le séparateur de date</string>
     <string name="align_widget_bottom">Alignement en bas</string>
     <string name="font_size">Taille de police</string>
@@ -30,7 +31,7 @@
     <string name="text_alignment">Alignement du texte</string>
     <string name="prefs_title_editing_default_config">Modification de la configuration par défaut</string>
     <string name="prefs_title_general">Général</string>
-    <string name="prefs_title_date_time">Date et heure</string>
+    <string name="prefs_title_date_time_location">Date et heure, Lieu</string>
     <string name="prefs_title_appearance">Apparence</string>
     <string name="no_upcoming_events">Aucun événement à venir</string>
     <string name="active_widgets">Configuration du widget</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -8,6 +8,7 @@
     <string name="show_action_buttons">क्रिया बटन दिखाएं</string>
     <string name="show_no_upcoming_events">\"कोई आगामी घटनाओं का पाठ नहीं दिखाएं\" टेक्स्ट दिखाएं</string>
     <string name="use_12_hour_format">12 घंटे का प्रारूप उपयोग करें</string>
+    <string name="show_location">स्थान दिखाएं</string>
     <string name="date_separator_visible">तिथि विभाजक दिखाएं</string>
     <string name="align_widget_bottom">निचली संरेखण</string>
     <string name="font_size">फ़ॉन्ट आकार</string>
@@ -30,7 +31,7 @@
     <string name="text_alignment">पाठ संरेखण</string>
     <string name="prefs_title_editing_default_config">डिफ़ॉल्ट कॉन्फ़िगरेशन संपादन</string>
     <string name="prefs_title_general">सामान्य</string>
-    <string name="prefs_title_date_time">तारीख और समय</string>
+    <string name="prefs_title_date_time_location">तारीख और समय, स्थान</string>
     <string name="prefs_title_appearance">दिखावट</string>
     <string name="no_upcoming_events">कोई आगामी घटनाएँ नहीं</string>
     <string name="active_widgets">"विजेट कॉन्फ़िगरेशन "</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -8,6 +8,7 @@
     <string name="show_action_buttons">Mostra pulsanti di azione</string>
     <string name="show_no_upcoming_events">Mostra il testo \"Nessun evento imminente\"</string>
     <string name="use_12_hour_format">Usa il formato a 12 ore</string>
+    <string name="show_location">Mostra luogo</string>
     <string name="date_separator_visible">Mostra separatore data</string>
     <string name="align_widget_bottom">Allineamento in basso</string>
     <string name="font_size">Dimensione del carattere</string>
@@ -30,7 +31,7 @@
     <string name="text_alignment">Allineamento del testo</string>
     <string name="prefs_title_editing_default_config">Modifica della configurazione predefinita</string>
     <string name="prefs_title_general">Generale</string>
-    <string name="prefs_title_date_time">Data e ora</string>
+    <string name="prefs_title_date_time_location">Data e ora, Luogo</string>
     <string name="prefs_title_appearance">Aspetto</string>
     <string name="no_upcoming_events">Nessun evento in arrivo</string>
     <string name="active_widgets">Configurazione del widget</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -8,6 +8,7 @@
     <string name="show_action_buttons">Pokaż przyciski akcji</string>
     <string name="show_no_upcoming_events">Pokaż tekst \"Brak nadchodzących wydarzeń\"</string>
     <string name="use_12_hour_format">Używaj formatu 12-godzinnego</string>
+    <string name="show_location">Pokaż lokalizację</string>
     <string name="date_separator_visible">Pokaż separator daty</string>
     <string name="align_widget_bottom">Wyrównanie do dołu</string>
     <string name="font_size">Rozmiar czcionki</string>
@@ -31,7 +32,7 @@
     <string name="text_alignment">Wyrównanie tekstu</string>
     <string name="prefs_title_editing_default_config">Edycja domyślnej konfiguracji</string>
     <string name="prefs_title_general">Ogólne</string>
-    <string name="prefs_title_date_time">Data i czas</string>
+    <string name="prefs_title_date_time_location">Data i czas, Lokalizacja</string>
     <string name="prefs_title_appearance">Wygląd</string>
     <string name="no_upcoming_events">Brak nadchodzących wydarzeń</string>
     <string name="active_widgets">Konfiguracja widżetu</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -8,6 +8,7 @@
     <string name="show_action_buttons">Mostrar botões de ação</string>
     <string name="show_no_upcoming_events">Mostrar texto \"Nenhum evento futuro\"</string>
     <string name="use_12_hour_format">Usar formato de 12 horas</string>
+    <string name="show_location">Mostrar local</string>
     <string name="date_separator_visible">Mostrar separador de data</string>
     <string name="align_widget_bottom">Alinhamento inferior</string>
     <string name="font_size">Tamanho da fonte</string>
@@ -31,7 +32,7 @@
     <string name="text_alignment">Alinhamento de texto</string>
     <string name="prefs_title_editing_default_config">Editando a configuração padrão</string>
     <string name="prefs_title_general">Geral</string>
-    <string name="prefs_title_date_time">Data e Hora</string>
+    <string name="prefs_title_date_time_location">Data e Hora, Local</string>
     <string name="prefs_title_appearance">Aparência</string>
     <string name="no_upcoming_events">Nenhum evento futuro</string>
     <string name="active_widgets">Configuração do widget</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -8,6 +8,7 @@
     <string name="show_action_buttons">แสดงปุ่มดำเนินการ</string>
     <string name="show_no_upcoming_events">แสดงข้อความ \"ไม่มีกิจกรรมที่จะมาถึง\"</string>
     <string name="use_12_hour_format">ใช้รูปแบบ 12 ชั่วโมง</string>
+    <string name="show_location">แสดงตำแหน่ง</string>
     <string name="date_separator_visible">แสดงตัวคั่นวันที่</string>
     <string name="align_widget_bottom">การจัดแนวด้านล่าง</string>
     <string name="font_size">ขนาดตัวอักษร</string>
@@ -31,7 +32,7 @@
     <string name="text_alignment">การจัดตำแหน่งข้อความ</string>
     <string name="prefs_title_editing_default_config">แก้ไขการกำหนดค่าเริ่มต้น</string>
     <string name="prefs_title_general">ทั่วไป</string>
-    <string name="prefs_title_date_time">วันที่และเวลา</string>
+    <string name="prefs_title_date_time_location">วันที่และเวลา, สถานที่</string>
     <string name="prefs_title_appearance">"ลักษณะ "</string>
     <string name="no_upcoming_events">ไม่มีกิจกรรมที่จะเกิดขึ้น</string>
     <string name="active_widgets">การกำหนดค่าวิดเจ็ต</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -8,6 +8,7 @@
     <string name="show_action_buttons">显示操作按钮</string>
     <string name="show_no_upcoming_events">显示没有即将到来的事件文本</string>
     <string name="use_12_hour_format">使用12小时制</string>
+    <string name="show_location">显示位置</string>
     <string name="date_separator_visible">显示日期分隔符</string>
     <string name="align_widget_bottom">底部对齐</string>
     <string name="font_size">字体大小</string>
@@ -30,7 +31,7 @@
     <string name="text_alignment">"文字对齐 "</string>
     <string name="prefs_title_editing_default_config">编辑默认配置</string>
     <string name="prefs_title_general">通用</string>
-    <string name="prefs_title_date_time">日期和时间</string>
+    <string name="prefs_title_date_time_location">日期和时间, 位置</string>
     <string name="prefs_title_appearance">外观</string>
     <string name="no_upcoming_events">暂无即将到来的事件</string>
     <string name="active_widgets">小部件配置</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,7 +5,7 @@
     <string name="tap_to_set_up">%1$s needs access to your calendar to show your events.\n\n Tap here and grant access.</string>
     <string name="prefs_title_editing_default_config">Editing default configuration</string>
     <string name="prefs_title_general">General</string>
-    <string name="prefs_title_date_time">Date and Time</string>
+    <string name="prefs_title_date_time_location">Date and Time, Location</string>
     <string name="prefs_title_appearance">Appearance</string>
     <string name="select_calendars">Select calendars</string>
     <string name="number_of_days_to_display">Number of days to display</string>
@@ -13,6 +13,7 @@
     <string name="show_action_buttons">Show action buttons</string>
     <string name="show_no_upcoming_events">Show no upcoming events text</string>
     <string name="use_12_hour_format">Use 12 hour format</string>
+    <string name="show_location">Show location</string>
     <string name="date_separator_visible">Show date separator</string>
     <string name="align_widget_bottom">Bottom alignment</string>
     <string name="font_size">Font size</string>


### PR DESCRIPTION
This commit introduces a new preference option allowing users to toggle the display of event locations within the widget.

- Added a "Show location" checkbox in the "Date and Time, Location" section of the preferences screen.
- Implemented the corresponding logic in `AgendaWidgetPrefs` to store and retrieve this preference.
- Updated `EventsRemoteViewsFactory` to respect the "Show location" setting when generating event text.
- Added necessary string resources for various languages.
- Included "SHOW_LOCATION" in `AgendaWidgetLogger.PrefsScreenItemName` for analytics.
- Renamed the "Date and Time" preferences section title to "Date and Time, Location" to reflect the new option.